### PR TITLE
ADD: karma/mocha/chai test framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,5 +24,5 @@
 
 ### Devtools
 - From the repository:
-    - To run the test suite: `npm test` (tests don't exist yet)
+    - To run the test suite: `npm test`
     - To lint: `npm run lint`

--- a/package.json
+++ b/package.json
@@ -4,13 +4,22 @@
   "description": "",
   "main": "src/app.js",
   "scripts": {
-    "lint": "jscs src --preset=google && echo \"Linting passed.\" || exit 0",
-    "test": "echo \"No tests yet\" && exit 1"
+    "lint": "jscs . --preset=google && echo \"Linting passed.\" || exit 0",
+    "karma-mocha": "./node_modules/karma/bin/karma start test/karma.mocha.conf.js",
+    "test": "npm run karma-mocha && echo \"\nTests passed.\""
   },
   "author": "",
   "license": "ISC",
   "dependencies": {
     "express": "^4.14.0",
     "socket.io": "^1.7.2"
+  },
+  "devDependencies": {
+    "chai": "^3.5.0",
+    "karma": "^1.3.0",
+    "karma-chai": "^0.1.0",
+    "karma-mocha": "^1.3.0",
+    "karma-phantomjs-launcher": "^1.0.2",
+    "mocha": "^3.2.0"
   }
 }

--- a/src/public/js/main.js
+++ b/src/public/js/main.js
@@ -1,3 +1,4 @@
+'use strict';
 (function() {
   $.get('constants')
    .done(main)

--- a/src/public/js/rs.js
+++ b/src/public/js/rs.js
@@ -1,4 +1,4 @@
-`use strict`;
+'use strict';
 var RS = (function() {
   // (actually ROT-13 right now, as a dummy example. We can replace w/ RS)
   var ROT = 13;
@@ -23,6 +23,6 @@ var RS = (function() {
 
   return {
     encode: encode,
-    decode: decode
+    decode: decode,
   };
 })();

--- a/src/public/js/rs.js
+++ b/src/public/js/rs.js
@@ -23,6 +23,6 @@ var RS = (function() {
 
   return {
     encode: encode,
-    decode: decode,
+    decode: decode
   };
 })();

--- a/test/client/rs.test.js
+++ b/test/client/rs.test.js
@@ -3,7 +3,7 @@ describe('The RS implementation', function() {
     assert.equal(RS.encode('HELLO'), 'URYY\\');
   });
 
-  it('decodes URYYB as HELLO. (ROT13 example)', function() {
+  it('decodes URYY\\ as HELLO. (ROT13 example)', function() {
     assert.equal(RS.decode('URYY\\'), 'HELLO');
   });
 });

--- a/test/client/rs.test.js
+++ b/test/client/rs.test.js
@@ -1,0 +1,9 @@
+describe('The RS implementation', function() {
+  it('encodes HELLO as URYY\\. (ROT13 example)', function() {
+    assert.equal(RS.encode('HELLO'), 'URYY\\');
+  });
+
+  it('decodes URYYB as HELLO. (ROT13 example)', function() {
+    assert.equal(RS.decode('URYY\\'), 'HELLO');
+  });
+});

--- a/test/karma.mocha.conf.js
+++ b/test/karma.mocha.conf.js
@@ -1,0 +1,51 @@
+// Karma configuration
+// Generated on Thu Jan 12 2017 15:40:58 GMT-0500 (EST)
+
+module.exports = function(config) {
+  config.set({
+
+    // base path that will be used to resolve all patterns (eg. files, exclude)
+    basePath: '',
+
+    // frameworks to use
+    // available frameworks: https://npmjs.org/browse/keyword/karma-adapter
+    frameworks: ['mocha', 'chai'],
+
+    // list of files / patterns to load in the browser
+    files: [
+      'client/*.test.js',
+      '../src/public/js/*.js'
+    ],
+
+    // list of files / patterns to exclude
+    exclude: [
+      '../src/public/js/main.js'
+    ],
+
+    // test results reporter to use
+    // possible values: 'dots', 'progress'
+    // available reporters: https://npmjs.org/browse/keyword/karma-reporter
+    reporters: ['progress'],
+
+    // web server port
+    port: 9876,
+
+    // enable / disable colors in the output (reporters and logs)
+    colors: true,
+
+    // level of logging
+    // possible values: config.LOG_DISABLE || config.LOG_ERROR || config.LOG_WARN || config.LOG_INFO || config.LOG_DEBUG
+    logLevel: config.LOG_INFO,
+
+    // enable / disable watching file and executing tests whenever any file changes
+    autoWatch: false,
+
+    // start these browsers
+    // available browser launchers: https://npmjs.org/browse/keyword/karma-launcher
+    browsers: ['PhantomJS'],
+
+    // Continuous Integration mode
+    // if true, Karma captures browsers, runs the tests and exits
+    singleRun: true,
+  });
+};


### PR DESCRIPTION
Write clientside js tests at `test/client/whatever.test.js` so the karma conf can find them :) I set up a sample `rs.test.js` with encode/decode tests using the placeholder ROT13 cipher.

Looking at that sample `rs.test.js` file -- from what I've seen, convention is to line the text in the `describe` up with the text in each `it` so together they form a full sentence -- e.g. "The RS implementation encodes HELLO as URYY\\. (ROT13 example)". dunno if that's at all similar to how you test go