### PR TITLE
FIX: issues in polynomialDiv and encodeRSBlock

### DIFF
--- a/src/public/js/rs.js
+++ b/src/public/js/rs.js
@@ -20,10 +20,11 @@ var RS = (function() {
   // n - k is the number of code symbols added.
   // Encoding procedure has the largest order coefficient on the left
   // and the smallest on the right. IE: [1,2,3] -> x^2 + 2x + 3
-  // The largest order coeeficient is the [0] element of msg so as
+  // The largest order coefficient is the [0] element of msg so as
   // to maintain the ordering of [msg, code symbols] in the coded msg.
   function encodeRSBlock(msg, n, k) {
-    var remainder = UTIL.polynomialDiv(msg, genPoly, n, k);
+    var paddedMsg = msg.concat(new Array(n - k).fill(0));
+    var remainder = UTIL.polynomialDiv(paddedMsg, genPoly, n, k);
     var codedMsg = new Uint8Array(n);
     for (var i = 0; i < k; i++) {
       codedMsg[i] = msg[i];

--- a/src/public/js/util.js
+++ b/src/public/js/util.js
@@ -146,6 +146,9 @@ var UTIL = (function() {
   }
 
   function polynomialDiv(dividend, divisor, n, k) {
+    // Make a copy of dividend to avoid modifying input
+    dividend = dividend.slice(0);
+
     var divLen = n - k + 1;
     if (divisor.length != divLen || dividend.length != n || k >= n) {
       throw new Error('Incorrect n, k, or length of dividend or divisor');


### PR DESCRIPTION
two things -- 

1) the block comment for `encodeRSBlock` specifies that the message should be passed in as a length k block -- but the `polynomialDiv` function expects it to be of length n. unless I'm missing something, we forgot about "padding" the message by multiplying it by x^(n-k) -- line 26 handles this now
2) the `polynomialDiv` function in util was modifying the input `dividend`, so the `codedMsg[i] = msg[i]` copying wasn't working as expected. Fixed by making dividend a copy of itself at the beginning of polynomialDiv (kind of a weird workaround but I think this is how I've seen people handle this kind of thing in js)

let me know if I'm understanding either of these things differently than you are! could be missing something.